### PR TITLE
Fix warn on $_SERVER['HTTPS'] & other var

### DIFF
--- a/apps/roundcube/src/lib/RoundcubeLogin.class.php
+++ b/apps/roundcube/src/lib/RoundcubeLogin.class.php
@@ -286,10 +286,10 @@ class RoundcubeLogin {
 			return;
 
 		// Get current session ID cookie
-		if ($_COOKIE['roundcube_sessid'])
+		if (isset($_COOKIE['roundcube_sessid']) && $_COOKIE['roundcube_sessid'])
 			$this -> rcSessionID = $_COOKIE['roundcube_sessid'];
 
-		if ($_COOKIE['roundcube_sessauth'])
+		if (isset($_COOKIE['roundcube_sessauth']) && $_COOKIE['roundcube_sessauth'])
 			$this -> rcSessionAuth = $_COOKIE['roundcube_sessauth'];
 
 		// Send request and maybe receive new session ID


### PR DESCRIPTION
Fix some warning with non HTTPS server, because variable is not set.
