### PR TITLE
Fix personal settings link (properly now)

### DIFF
--- a/apps/roundcube/src/templates/part.error.no-settings.php
+++ b/apps/roundcube/src/templates/part.error.no-settings.php
@@ -2,6 +2,6 @@
     <h1><?php echo $l->t("You don't have any email account configured yet.") ?></h1>
     <div>
         <small><?php echo $l->t('You can manage your email accounts here:') ?></small>
-	    <a class="button" href="<?php print_unescaped(link_to('index.php', 'settings/personal')) ?>"><?php echo $l -> t('Settings'); ?></a>
+	    <a class="button" href="<?php print_unescaped(OCP\Util::linkToRoute('settings_personal')) ?>"><?php echo $l -> t('Settings'); ?></a>
 	</div>
 </div>


### PR DESCRIPTION
refs #122
Got an answer from the owncloud team how to link to the user's settings page properly:
http://mail.kde.org/pipermail/owncloud/2013-August/010143.html
