### PR TITLE
Switched to using a relative protocol for loading roundcube in the iframe.

### DIFF
--- a/apps/roundcube/src/lib/RoundcubeLogin.class.php
+++ b/apps/roundcube/src/lib/RoundcubeLogin.class.php
@@ -288,7 +288,8 @@ class OC_RoundCube_Login {
 		# others not listed here."
 		# (http://www.php.net/manual/en/reserved.variables.server.php)
 		$port = (isset($_SERVER['HTTPS']) && $_SERVER["HTTPS"] || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') ? 443 : 80;
-		$protocol = (($port == 443) ? "https://" : "http://");
+		# Use a relative protocol in case we/roundcube are behind an SSL proxy (see http://tools.ietf.org/html/rfc3986#section-4.2).
+		$protocol = '//';
 		$path = $protocol . rtrim($this -> rcHost, "/") . "/" . ltrim($this -> rcPath, "/");
 		return $path;
 	}


### PR DESCRIPTION
Previously, protocol detection for the location of the roundcube site
was done via port. This breaks when owncloud is behind an SSL proxy,
giving an X-Frame-Options error.
