### PR TITLE
double are not correct, real are sql99,see deatils

### DIFF
--- a/storagecharts2/src/main/php/appinfo/database.xml
+++ b/storagecharts2/src/main/php/appinfo/database.xml
@@ -36,13 +36,13 @@
 			</field>
 			<field>
 				<name>stc_used</name>
-				<type>integer</type>
+				<type>real</type>
 				<notnull>true</notnull>
 				<length>30</length>
 			</field>
 			<field>
 				<name>stc_total</name>
-				<type>integer</type>
+				<type>real</type>
 				<notnull>true</notnull>
 				<length>30</length>
 			</field>


### PR DESCRIPTION
investigating http://home.comcast.net/~jbondor/SQLNutshell/23SQL99AndVendorSpecificDatatypes.htm real must do not fail when install in mayor sql databases, **i tested that in postgresql (real and double work) and sqlite (real work)**, i do not have mysql, but i see in https://mariadb.com/kb/en/sql-99-complete-really/02-general-concepts/sql-data-types/ that this are sure work, with that solved definitively the #240 issue and closed #240 definitivelly ... please make tests **(tested and works for sqlite and postgres**, i could tested in oracle due limitation of resources)
